### PR TITLE
Add configuration for Google Maps API key

### DIFF
--- a/Ritveer/ritveer_project/.env.example
+++ b/Ritveer/ritveer_project/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and populate with actual credentials
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key

--- a/Ritveer/ritveer_project/src/config/__init__.py
+++ b/Ritveer/ritveer_project/src/config/__init__.py
@@ -1,0 +1,3 @@
+from .settings import settings
+
+__all__ = ["settings"]

--- a/Ritveer/ritveer_project/src/config/settings.py
+++ b/Ritveer/ritveer_project/src/config/settings.py
@@ -1,0 +1,13 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+    GOOGLE_MAPS_API_KEY: str | None = None
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()


### PR DESCRIPTION
## Summary
- add config module to load environment variables via pydantic
- provide example .env with Google Maps API key

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c61dd57334833092451b63b14918b2