### PR TITLE
Expose Google Maps search and geocoding APIs

### DIFF
--- a/Ritveer/ritveer_project/.env.example
+++ b/Ritveer/ritveer_project/.env.example
@@ -1,0 +1,2 @@
+# Copy to .env and populate with actual credentials
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key

--- a/Ritveer/ritveer_project/src/api/maps.py
+++ b/Ritveer/ritveer_project/src/api/maps.py
@@ -1,0 +1,22 @@
+from fastapi import APIRouter, HTTPException
+from src.tools.google_maps_tools import search_places, geocode_address
+
+router = APIRouter(prefix="/maps", tags=["maps"])
+
+
+@router.get("/search")
+def map_search(query: str, location: str, radius: int = 5000):
+    """Search for places near a location using Google Maps."""
+    result = search_places(query=query, location=location, radius=radius)
+    if result.get("status") == "failed":
+        raise HTTPException(status_code=500, detail=result.get("message"))
+    return result
+
+
+@router.get("/geocode")
+def map_geocode(address: str):
+    """Geocode an address into latitude and longitude using Google Maps."""
+    result = geocode_address(address)
+    if result.get("status") == "failed":
+        raise HTTPException(status_code=500, detail=result.get("message"))
+    return result

--- a/Ritveer/ritveer_project/src/config/__init__.py
+++ b/Ritveer/ritveer_project/src/config/__init__.py
@@ -1,0 +1,3 @@
+from .settings import settings
+
+__all__ = ["settings"]

--- a/Ritveer/ritveer_project/src/config/settings.py
+++ b/Ritveer/ritveer_project/src/config/settings.py
@@ -1,0 +1,13 @@
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+    GOOGLE_MAPS_API_KEY: str | None = None
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+
+settings = Settings()

--- a/Ritveer/ritveer_project/src/main.py
+++ b/Ritveer/ritveer_project/src/main.py
@@ -20,6 +20,7 @@ from .api.catalog import router as catalog_router
 from .api.catalog_share import router as catalog_share_router
 from .api.suppliers import router as suppliers_router
 from .api.research import router as research_router
+from .api.maps import router as maps_router
 from .state.store import reset_state
 # from .api.suppliers import router as suppliers_router  # TODO: Implement
 from src.tools.policy import policy as policy_store, env_overrides
@@ -52,6 +53,7 @@ app.include_router(catalog_router)
 app.include_router(catalog_share_router)
 app.include_router(suppliers_router)
 app.include_router(research_router)
+app.include_router(maps_router)
 # app.state.workflow = workflow_app  # TODO: Fix imports
 
 @app.post("/invoke")

--- a/Ritveer/ritveer_project/src/tools/google_maps_tools.py
+++ b/Ritveer/ritveer_project/src/tools/google_maps_tools.py
@@ -1,53 +1,43 @@
 import requests
-from typing import Dict, Any, List
+from typing import Dict, Any
 from config.settings import settings
 
+
 def search_places(query: str, location: str, radius: int = 5000) -> Dict[str, Any]:
-    """
-    Searches for places using the Google Maps Places API.
-
-    Args:
-        query: The text search string (e.g., "kiosk").
-        location: The latitude and longitude around which to retrieve place information (e.g., "34.0522,-118.2437").
-        radius: Defines the distance (in meters) within which to return place results. The maximum allowed radius is 50,000 meters.
-
-    Returns:
-        A dictionary containing the search results from Google Maps Places API.
-    """
+    """Search for places using the Google Maps Places API."""
     print(f"GOOGLE MAPS TOOL: Searching for places with query '{query}' near '{location}' within {radius} meters.")
-    
     api_key = settings.GOOGLE_MAPS_API_KEY
     if not api_key:
         return {"status": "failed", "message": "Google Maps API Key not configured."}
-
     base_url = "https://maps.googleapis.com/maps/api/place/textsearch/json"
-    params = {
-        "query": query,
-        "location": location,
-        "radius": radius,
-        "key": api_key
-    }
-
+    params = {"query": query, "location": location, "radius": radius, "key": api_key}
     try:
         response = requests.get(base_url, params=params)
-        response.raise_for_status()  # Raise an exception for HTTP errors
+        response.raise_for_status()
         return response.json()
     except requests.exceptions.RequestException as e:
         print(f"GOOGLE MAPS TOOL: Error searching places: {e}")
         return {"status": "failed", "message": f"Google Maps API error: {str(e)}"}
 
+
+def geocode_address(address: str) -> Dict[str, Any]:
+    """Geocode a human readable address into latitude and longitude."""
+    print(f"GOOGLE MAPS TOOL: Geocoding address '{address}'.")
+    api_key = settings.GOOGLE_MAPS_API_KEY
+    if not api_key:
+        return {"status": "failed", "message": "Google Maps API Key not configured."}
+    base_url = "https://maps.googleapis.com/maps/api/geocode/json"
+    params = {"address": address, "key": api_key}
+    try:
+        response = requests.get(base_url, params=params)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"GOOGLE MAPS TOOL: Error geocoding address: {e}")
+        return {"status": "failed", "message": f"Google Maps API error: {str(e)}"}
+
+
 def book_kiosk(place_id: str, booking_details: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Simulates booking a kiosk at a given place_id.
-    In a real scenario, this would involve interaction with a booking system.
-
-    Args:
-        place_id: The Google Place ID of the kiosk location.
-        booking_details: A dictionary containing booking-specific information (e.g., date, time, duration).
-
-    Returns:
-        A dictionary indicating the success or failure of the booking.
-    """
+    """Simulate booking a kiosk at a given place_id."""
     print(f"GOOGLE MAPS TOOL: Simulating booking kiosk at place ID '{place_id}' with details: {booking_details}")
-    # Simulate a successful booking for now
     return {"status": "success", "message": f"Kiosk at {place_id} booked successfully (simulated).", "booking_id": "BOOK" + place_id[:5].upper() + "123"}


### PR DESCRIPTION
## Summary
- expand Google Maps utilities with geocoding support
- add `/maps` endpoints to search places and geocode addresses
- wire maps router into FastAPI application

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c61dd57334833092451b63b14918b2